### PR TITLE
Add --socket=system-bus and session-bus

### DIFF
--- a/org.lutris.Lutris.json
+++ b/org.lutris.Lutris.json
@@ -10,11 +10,13 @@
     "--socket=x11",
     "--socket=wayland",
     "--socket=pulseaudio",
+    "--socket=system-bus",
+    "--socket=session-bus",
     "--share=ipc",
     "--share=network",
     "--device=all",
     "--filesystem=host",
-    "--allow=multiarch"
+    "--allow=multiarch",
   ],
   "modules": [
     {

--- a/org.lutris.Lutris.json
+++ b/org.lutris.Lutris.json
@@ -16,7 +16,7 @@
     "--share=network",
     "--device=all",
     "--filesystem=host",
-    "--allow=multiarch",
+    "--allow=multiarch"
   ],
   "modules": [
     {


### PR DESCRIPTION
> Access to the entire bus with --socket=system-bus or --socket=session-bus should be avoided, unless the application is a development tool.

We should likely find a better solution around this.