### PR TITLE
Add xrandr

### DIFF
--- a/org.lutris.Lutris.json
+++ b/org.lutris.Lutris.json
@@ -18,6 +18,16 @@
   ],
   "modules": [
     {
+      "name": "xrandr",
+      "sources": [
+	{
+          "type": "archive",
+          "url": "https://xorg.freedesktop.org/archive/individual/app/xrandr-1.5.0.tar.bz2",
+          "sha256": "c1cfd4e1d4d708c031d60801e527abc9b6d34b85f2ffa2cadd21f75ff38151cd"
+        }
+      ]
+    },
+    {
       "name": "cpython",
       "sources": [
         {


### PR DESCRIPTION
Was getting the following error...
```
FileNotFoundError: [Errno 2] No such file or directory: 'xrandr': 'xrandr'
```

Thank you to TingPing from https://github.com/TingPing/flatpak-packages/blob/e2dbd024acc24339e79c23e5ea220b10cfae1a59/net.lutris.Lutris.json#L19-L26