### PR TITLE
Add gnome-desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ To compile Lutris as a Flatpak, you'll need both [Flatpak](https://flatpak.org/)
 ## Clean up
 
 ```
-flatpak uninstall --user org.lutris.Lutris
-rm -rf ~/.var/app/org.lutris.Lutris .flatpak-builder
+flatpak uninstall --user net.lutris.Lutris
+rm -rf ~/.var/app/net.lutris.Lutris .flatpak-builder
 flatpak remote-delete lutris
 ```
 

--- a/net.lutris.Lutris.yaml
+++ b/net.lutris.Lutris.yaml
@@ -49,6 +49,11 @@ add-extensions:
     enable-if: active-gl-driver
 
 modules:
+- name: gnome-desktop
+  sources:
+  - type: archive
+    url: "https://download.gnome.org/sources/gnome-desktop/3.30/gnome-desktop-3.30.2.tar.xz"
+    sha256: 5475e693cb7ada801a36e8d16bc0dbb58930b793f455419b205cd9241d63d14c
 - name: psmisc
   sources:
   - type: archive

--- a/net.lutris.Lutris.yaml
+++ b/net.lutris.Lutris.yaml
@@ -52,8 +52,8 @@ modules:
 - name: gnome-desktop
   sources:
   - type: archive
-    url: "https://download.gnome.org/sources/gnome-desktop/3.30/gnome-desktop-3.30.2.tar.xz"
-    sha256: 5475e693cb7ada801a36e8d16bc0dbb58930b793f455419b205cd9241d63d14c
+    url: "https://download.gnome.org/sources/gnome-desktop/3.32/gnome-desktop-3.32.0.tar.xz"
+    sha256: a6393dc5fc29fc0652ac84c73b3da205d0b0168128c4cf6d27797a08f3d07b54
 - name: psmisc
   sources:
   - type: archive


### PR DESCRIPTION
Bundling `gnome-desktop` 3.20 fixes the broken GnomeDesktop namespace. Thanks to @AsciiWolf and @LeandroStanger for help getting this up!

Fixes #20